### PR TITLE
Parallelize image downloads and `phash` computation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspotlightarchiver"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
   { name="yell0wsuit" },
 ]

--- a/src/pyspotlightarchiver/helpers/download_helper.py
+++ b/src/pyspotlightarchiver/helpers/download_helper.py
@@ -1,8 +1,18 @@
 """Module for downloading images from API"""
 
 import os
+import threading
 import requests
 from rich import print as rprint
+
+_thread_local = threading.local()
+
+
+def _get_session():
+    """Return a per-thread requests.Session (creates one if needed)."""
+    if not hasattr(_thread_local, "session"):
+        _thread_local.session = requests.Session()
+    return _thread_local.session
 
 
 def get_save_dir(api_ver, save_dir=None):
@@ -43,7 +53,7 @@ def download_image(url, save_dir=None, api_ver=None):
     Otherwise, saves to the appropriate folder based on api_ver.
     Returns the image file path.
     """
-    response = requests.get(url, timeout=10)
+    response = _get_session().get(url, timeout=10)
     response.raise_for_status()
     save_dir = get_save_dir(api_ver, save_dir)
     filename = os.path.basename(url.split("?")[0])

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -3,6 +3,7 @@
 import os
 import random
 import time
+from concurrent.futures import ThreadPoolExecutor
 from rich import print as rprint
 
 from pyspotlightarchiver.helpers.download_helper import (
@@ -41,6 +42,20 @@ from pyspotlightarchiver.utils.countdown import (
 )
 
 CONSECUTIVE_MAX = 50
+MAX_DOWNLOAD_WORKERS = 8
+
+
+def _download_entry(entry, orientation, api_ver, save_dir):
+    """Worker: download image(s) for one entry and compute phash.
+    Returns (entry, list of (url, path, filename, phash)).
+    """
+    paths = download_images(entry, orientation, api_ver=api_ver, save_dir=save_dir)
+    results = []
+    for url, path in paths.items():
+        if path:
+            phash = compute_phash(path)
+            results.append((url, path, os.path.basename(path), phash))
+    return entry, results
 
 
 def _api_call(api_ver, locale, orientation, verbose=False):
@@ -228,7 +243,9 @@ def _download_multiple_for_locale(
     downloaded = 0
     already_downloaded = 0
 
-    for i, entry in enumerate(entries):
+    # Pre-filter entries already in DB (only works for single-orientation where image_url exists)
+    new_entries = []
+    for entry in entries:
         url = entry.get("image_url")
         if url:
             record = get_image_url_from_db(url, save_dir)
@@ -238,30 +255,39 @@ def _download_multiple_for_locale(
                     rprint(f"ℹ️ [gray]Image already downloaded:[/gray] {url}")
                     already_downloaded += 1
                     continue
-        paths = download_images(entry, orientation, api_ver=api_ver, save_dir=save_dir)
-        if paths:
-            for url, path in paths.items():
-                if path:
-                    filename = os.path.basename(path)
-                    add_image_url_to_db(
-                        url, compute_phash(path), filename, save_dir=save_dir
+        new_entries.append(entry)
+
+    if not new_entries:
+        return downloaded, already_downloaded
+
+    # Parallel download + phash
+    workers = min(len(new_entries), MAX_DOWNLOAD_WORKERS)
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [
+            executor.submit(_download_entry, entry, orientation, api_ver, save_dir)
+            for entry in new_entries
+        ]
+        for i, future in enumerate(futures):
+            entry, results = future.result()
+            for url, path, filename, phash in results:
+                add_image_url_to_db(url, phash, filename, save_dir=save_dir)
+                if embed_exif and locale != "all":
+                    set_exif_metadata_exiftool(
+                        path,
+                        title=entry.get("title") or entry.get("picture_title"),
+                        copyright_text=entry.get("copyright"),
+                        caption_title=entry.get("caption_title"),
+                        caption_description=entry.get("caption_description"),
+                        exiftool_path=exiftool_path,
+                        verbose=verbose,
                     )
-                    if embed_exif and locale != "all":
-                        set_exif_metadata_exiftool(
-                            path,
-                            title=entry.get("title") or entry.get("picture_title"),
-                            copyright_text=entry.get("copyright"),
-                            caption_title=entry.get("caption_title"),
-                            caption_description=entry.get("caption_description"),
-                            exiftool_path=exiftool_path,
-                            verbose=verbose,
-                        )
-                        rprint("✅ [green]EXIF metadata embedded[/green]")
-                    if verbose:
-                        rprint(
-                            f"✅ [green]LOG: [download_multiple_for_locale]Downloaded entry {i+1}:[/green] {url}"
-                        )
-                    downloaded += 1
+                    rprint("✅ [green]EXIF metadata embedded[/green]")
+                if verbose:
+                    rprint(
+                        f"✅ [green]LOG: [download_multiple_for_locale]"
+                        f"Downloaded entry {i + 1}:[/green] {url}"
+                    )
+                downloaded += 1
     return downloaded, already_downloaded
 
 


### PR DESCRIPTION
## Description

- Downloads within `--multiple` mode now run concurrently (up to 8 workers) via `ThreadPoolExecutor`, instead of one at a time
- Perceptual hash computation runs in parallel with downloads in the same worker
- `requests.Session` is reused per thread (via `threading.local`) to avoid repeated TCP handshakes