### PR TITLE
fix: remove dead ternary in `get_save_dir`, handle parallel worker errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspotlightarchiver"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name="yell0wsuit" },
 ]

--- a/src/pyspotlightarchiver/helpers/download_helper.py
+++ b/src/pyspotlightarchiver/helpers/download_helper.py
@@ -24,15 +24,9 @@ def get_save_dir(api_ver, save_dir=None):
         save_dir if save_dir else os.path.join(os.getcwd(), "downloaded_spotlight")
     )
     if api_ver == 3:
-        save_dir = (
-            os.path.join(base_dir, "1080p")
-            if save_dir
-            else os.path.join(base_dir, "1080p")
-        )
+        save_dir = os.path.join(base_dir, "1080p")
     elif api_ver == 4:
-        save_dir = (
-            os.path.join(base_dir, "4K") if save_dir else os.path.join(base_dir, "4K")
-        )
+        save_dir = os.path.join(base_dir, "4K")
     else:
         save_dir = base_dir
     os.makedirs(save_dir, exist_ok=True)

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -268,7 +268,11 @@ def _download_multiple_for_locale(
             for entry in new_entries
         ]
         for i, future in enumerate(futures):
-            entry, results = future.result()
+            try:
+                entry, results = future.result()
+            except Exception as exc:
+                rprint(f"⚠️ [yellow]Failed to download entry {i + 1}: {exc}[/yellow]")
+                continue
             for url, path, filename, phash in results:
                 add_image_url_to_db(url, phash, filename, save_dir=save_dir)
                 if embed_exif and locale != "all":


### PR DESCRIPTION
## Description

- Removed dead ternary in `get_save_dir`, both branches were identical
- Failed workers in the parallel download loop now log a warning and skip instead of aborting the entire batch
