### PR TITLE
fix: store locale cache in `--save-dir`, narrow broad exception catches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspotlightarchiver"
-version = "1.1.4"
+version = "1.1.5"
 authors = [
   { name="yell0wsuit" },
 ]

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -4,6 +4,7 @@ import os
 import random
 import time
 from concurrent.futures import ThreadPoolExecutor
+import requests
 from rich import print as rprint
 
 from pyspotlightarchiver.helpers.download_helper import (
@@ -110,7 +111,7 @@ def _download_for_locale(
     embed_exif=True,
     exiftool_path=None,
 ):
-    all_locales = get_locale_codes(api_ver)
+    all_locales = get_locale_codes(api_ver, save_dir)
     all_locales_lower = [l.lower() for l in all_locales]
     if locale not in all_locales_lower:
         rprint(
@@ -163,7 +164,7 @@ def _download_for_locale(
 def _download_for_all_locales(
     api_ver, orientation, verbose=False, save_dir=None, exiftool_path=None
 ):
-    all_locales = get_locale_codes(api_ver)
+    all_locales = get_locale_codes(api_ver, save_dir)
     locales_shuffled = all_locales[:]
     random.shuffle(locales_shuffled)
     for loc in locales_shuffled:
@@ -270,7 +271,7 @@ def _download_multiple_for_locale(
         for i, future in enumerate(futures):
             try:
                 entry, results = future.result()
-            except Exception as exc:
+            except (requests.exceptions.RequestException, OSError) as exc:
                 rprint(f"⚠️ [yellow]Failed to download entry {i + 1}: {exc}[/yellow]")
                 continue
             for url, path, filename, phash in results:
@@ -309,7 +310,7 @@ def download_multiple(
     Returns the number of images downloaded.
     """
 
-    all_locales = get_locale_codes(api_ver)
+    all_locales = get_locale_codes(api_ver, save_dir)
     locale = locale.lower()
 
     if locale == "all":

--- a/src/pyspotlightarchiver/utils/locale_data.py
+++ b/src/pyspotlightarchiver/utils/locale_data.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 from babel import localedata
-from babel.core import Locale
+from babel.core import Locale, UnknownLocaleError
 from pyspotlightarchiver.utils.exclude_locale import is_excluded
 
 
@@ -20,20 +20,21 @@ def generate_locale_codes():
                 code = f"{locale.language}-{locale.territory}"
                 if pattern.match(code):
                     locale_codes.add(code)
-        except Exception:
+        except (UnknownLocaleError, ValueError):
             continue
 
     return sorted(locale_codes)
 
 
-def get_cache_file(api_ver):
+def get_cache_file(api_ver, save_dir=None):
     """Get the cache file for a given API version."""
-    return os.path.join(os.getcwd(), ".cache", f"locale_cache_{api_ver}.json")
+    base = save_dir if save_dir else os.getcwd()
+    return os.path.join(base, ".cache", f"locale_cache_{api_ver}.json")
 
 
-def get_locale_codes(api_ver=3):
+def get_locale_codes(api_ver=3, save_dir=None):
     """Load locale codes from cache if available."""
-    cache_file = get_cache_file(api_ver)
+    cache_file = get_cache_file(api_ver, save_dir)
     if os.path.exists(cache_file):
         try:
             with open(cache_file, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Description

- Locale cache files (`locale_cache_{api_ver}.json`) now respect `--save-dir`, storing alongside the image cache in `save_dir/.cache/` instead of always using `os.getcwd()/.cache/`. Closes #1.
- Narrowed `except Exception` in `generate_locale_codes` to `(UnknownLocaleError, ValueError)`
- Narrowed `except Exception` in the parallel download worker to `(requests.exceptions.RequestException, OSError)`
