### PR TITLE
fix: reduce SQLite overhead and fix redundant work in download pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspotlightarchiver"
-version = "1.1.5"
+version = "1.1.6"
 authors = [
   { name="yell0wsuit" },
 ]

--- a/src/pyspotlightarchiver/helpers/download_db.py
+++ b/src/pyspotlightarchiver/helpers/download_db.py
@@ -1,12 +1,15 @@
 """Module to manage the SQLite database for downloaded images."""
 
 import sqlite3
+import threading
 import os
 from contextlib import closing
 from datetime import datetime
 from pyspotlightarchiver.helpers.download_helper import get_save_dir
 
 DB_FILENAME = "downloaded_images.sqlite"
+
+_thread_local = threading.local()
 
 
 def get_db_path(save_dir=None):
@@ -17,73 +20,80 @@ def get_db_path(save_dir=None):
         cache_dir = os.path.join(save_dir, ".cache")
     else:
         cache_dir = os.path.join(os.getcwd(), "downloaded_spotlight", ".cache")
-    os.makedirs(cache_dir, exist_ok=True)
     return os.path.join(cache_dir, DB_FILENAME)
+
+
+def _get_connection(save_dir=None):
+    """Return a per-thread persistent SQLite connection, creating one if needed."""
+    db_path = get_db_path(save_dir)
+    key = f"conn_{db_path}"
+    conn = getattr(_thread_local, key, None)
+    if conn is None:
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        setattr(_thread_local, key, conn)
+    return conn
 
 
 def init_db(save_dir):
     """Initialize the SQLite database and create the table if it doesn't exist."""
-    db_path = get_db_path(save_dir)
-    with sqlite3.connect(db_path) as conn:
-        with closing(conn.cursor()) as cursor:
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS downloaded_images (
-                    url TEXT PRIMARY KEY,
-                    phash TEXT,
-                    filename TEXT,
-                    downloaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                )
+    conn = _get_connection(save_dir)
+    with closing(conn.cursor()) as cursor:
+        cursor.execute(
             """
+            CREATE TABLE IF NOT EXISTS downloaded_images (
+                url TEXT PRIMARY KEY,
+                phash TEXT,
+                filename TEXT,
+                downloaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
-        conn.commit()
+        """
+        )
+    conn.commit()
 
 
 def add_image_url_to_db(url, phash, filename, save_dir):
     """Add a new image URL record to the database."""
-    db_path = get_db_path(save_dir)
-    with sqlite3.connect(db_path) as conn:
-        with closing(conn.cursor()) as cursor:
-            cursor.execute(
-                """
-                INSERT OR REPLACE INTO downloaded_images (url, phash, filename, downloaded_at)
-                VALUES (?, ?, ?, ?)
-            """,
-                (url, phash, filename, datetime.now()),
-            )
-        conn.commit()
+    conn = _get_connection(save_dir)
+    with closing(conn.cursor()) as cursor:
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO downloaded_images (url, phash, filename, downloaded_at)
+            VALUES (?, ?, ?, ?)
+        """,
+            (url, phash, filename, datetime.now()),
+        )
+    conn.commit()
 
 
 def get_image_url_from_db(url, save_dir):
     """Retrieve an image record by URL."""
-    db_path = get_db_path(save_dir)
-    with sqlite3.connect(db_path) as conn:
-        with closing(conn.cursor()) as cursor:
-            cursor.execute(
-                """
-                SELECT url, phash, filename, downloaded_at
-                FROM downloaded_images
-                WHERE url = ?
-            """,
-                (url,),
-            )
-            return cursor.fetchone()
+    conn = _get_connection(save_dir)
+    with closing(conn.cursor()) as cursor:
+        cursor.execute(
+            """
+            SELECT url, phash, filename, downloaded_at
+            FROM downloaded_images
+            WHERE url = ?
+        """,
+            (url,),
+        )
+        return cursor.fetchone()
 
 
 def get_image_filename_from_db(filename, save_dir):
     """Retrieve an image by filename."""
-    db_path = get_db_path(save_dir)
-    with sqlite3.connect(db_path) as conn:
-        with closing(conn.cursor()) as cursor:
-            cursor.execute(
-                """
-                SELECT filename
-                FROM downloaded_images
-                WHERE filename = ?
-                """,
-                (filename,),
-            )
-            return cursor.fetchone()
+    conn = _get_connection(save_dir)
+    with closing(conn.cursor()) as cursor:
+        cursor.execute(
+            """
+            SELECT filename
+            FROM downloaded_images
+            WHERE filename = ?
+            """,
+            (filename,),
+        )
+        return cursor.fetchone()
 
 
 def is_image_filename_valid(filename, save_dir, api_ver=None):
@@ -98,13 +108,12 @@ def get_all_images(save_dir):
     """
     Returns a list of (url, phash, filename) for all images in the DB.
     """
-    db_path = get_db_path(save_dir)
-    with sqlite3.connect(db_path) as conn:
-        with closing(conn.cursor()) as cursor:
-            cursor.execute(
-                """
-                SELECT url, phash, filename
-                FROM downloaded_images
-                """
-            )
-            return cursor.fetchall()
+    conn = _get_connection(save_dir)
+    with closing(conn.cursor()) as cursor:
+        cursor.execute(
+            """
+            SELECT url, phash, filename
+            FROM downloaded_images
+            """
+        )
+        return cursor.fetchall()

--- a/src/pyspotlightarchiver/helpers/download_db.py
+++ b/src/pyspotlightarchiver/helpers/download_db.py
@@ -104,6 +104,12 @@ def is_image_filename_valid(filename, save_dir, api_ver=None):
     return record is not None and os.path.exists(full_path)
 
 
+def is_file_on_disk(filename, save_dir, api_ver=None):
+    """Check if the image file exists on disk. Skips DB lookup — use when record is already confirmed."""
+    full_path = os.path.join(get_save_dir(api_ver, save_dir), filename)
+    return os.path.exists(full_path)
+
+
 def get_all_images(save_dir):
     """
     Returns a list of (url, phash, filename) for all images in the DB.

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -384,11 +384,8 @@ def download_multiple_until_exhausted(
     total_downloaded = 0
     total_already_downloaded = 0
     while consecutive < max_consecutive:
-        for _ in range(max_consecutive):
-            if consecutive >= max_consecutive:
-                break
-            time.sleep(2)
-            status = download_multiple(
+        time.sleep(2)
+        status = download_multiple(
                 api_ver,
                 locale,
                 orientation,

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -23,7 +23,7 @@ from pyspotlightarchiver.helpers.v4_helper import (
 from pyspotlightarchiver.helpers.download_db import (
     get_image_url_from_db,
     add_image_url_to_db,
-    is_image_filename_valid,
+    is_file_on_disk,
 )
 from pyspotlightarchiver.helpers.report_duplicates_helper import (
     report_duplicates,
@@ -78,7 +78,7 @@ def _download_both_orientations(
             record = get_image_url_from_db(url, save_dir)
             if record:
                 filename = record[2]  # 3rd element is filename
-                if is_image_filename_valid(filename, save_dir, api_ver):
+                if is_file_on_disk(filename, save_dir, api_ver):
                     rprint(f"ℹ️ [gray]Image already downloaded:[/gray] {url}")
                     continue
             path = download_image(url, api_ver=api_ver, save_dir=save_dir)
@@ -138,7 +138,7 @@ def _download_for_locale(
         record = get_image_url_from_db(url, save_dir)
         if record:
             filename = record[2]
-            if is_image_filename_valid(filename, save_dir, api_ver):
+            if is_file_on_disk(filename, save_dir, api_ver):
                 rprint(f"ℹ️ [gray]Image already downloaded:[/gray] {url}")
                 return True
         path = download_image(url, api_ver=api_ver, save_dir=save_dir)
@@ -252,7 +252,7 @@ def _download_multiple_for_locale(
             record = get_image_url_from_db(url, save_dir)
             if record:
                 filename = record[2]
-                if is_image_filename_valid(filename, save_dir, api_ver):
+                if is_file_on_disk(filename, save_dir, api_ver):
                     rprint(f"ℹ️ [gray]Image already downloaded:[/gray] {url}")
                     already_downloaded += 1
                     continue

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -349,14 +349,15 @@ def download_multiple(
             "already_downloaded": total_already_downloaded,
         }
 
-    if locale not in [l.lower() for l in all_locales]:
+    all_locales_lower = [l.lower() for l in all_locales]
+    if locale not in all_locales_lower:
         rprint(
             f"❗ [red]Locale '{locale}' is not valid.[/red] Use one of: {', '.join(all_locales)}"
         )
         return {"downloaded": 0, "already_downloaded": 0}
 
     # Use the correctly-cased locale from all_locales
-    real_locale = all_locales[[l.lower() for l in all_locales].index(locale)]
+    real_locale = all_locales[all_locales_lower.index(locale)]
     downloaded, already_downloaded = _download_multiple_for_locale(
         api_ver, real_locale, orientation, verbose, save_dir, embed_exif, exiftool_path
     )

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -72,19 +72,28 @@ def _download_both_orientations(
     entry, api_ver, save_dir=None, embed_exif=True, exiftool_path=None, verbose=False
 ):
     found = False
+    urls_to_download = []
     for key in ["image_url_landscape", "image_url_portrait"]:
         url = entry.get(key)
-        if url:
-            record = get_image_url_from_db(url, save_dir)
-            if record:
-                filename = record[2]  # 3rd element is filename
-                if is_file_on_disk(filename, save_dir, api_ver):
-                    rprint(f"ℹ️ [gray]Image already downloaded:[/gray] {url}")
-                    continue
-            path = download_image(url, api_ver=api_ver, save_dir=save_dir)
-            rprint(
-                f"✅ [green]{'Landscape' if key == 'image_url_landscape' else 'Portrait'} image saved to:[/green] {path}"
-            )
+        if not url:
+            continue
+        record = get_image_url_from_db(url, save_dir)
+        if record and is_file_on_disk(record[2], save_dir, api_ver):
+            rprint(f"ℹ️ [gray]Image already downloaded:[/gray] {url}")
+            continue
+        urls_to_download.append((key, url))
+
+    if not urls_to_download:
+        return found
+
+    def _fetch(key_url):
+        key, url = key_url
+        return key, url, download_image(url, api_ver=api_ver, save_dir=save_dir)
+
+    with ThreadPoolExecutor(max_workers=len(urls_to_download)) as executor:
+        for key, url, path in executor.map(_fetch, urls_to_download):
+            label = "Landscape" if key == "image_url_landscape" else "Portrait"
+            rprint(f"✅ [green]{label} image saved to:[/green] {path}")
             filename = os.path.basename(path)
             add_image_url_to_db(url, compute_phash(path), filename, save_dir=save_dir)
             if embed_exif:
@@ -386,35 +395,35 @@ def download_multiple_until_exhausted(
     while consecutive < max_consecutive:
         time.sleep(2)
         status = download_multiple(
-                api_ver,
-                locale,
-                orientation,
-                verbose=verbose,
-                save_dir=save_dir,
-                embed_exif=embed_exif,
-                exiftool_path=exiftool_path,
+            api_ver,
+            locale,
+            orientation,
+            verbose=verbose,
+            save_dir=save_dir,
+            embed_exif=embed_exif,
+            exiftool_path=exiftool_path,
+        )
+        downloaded = status.get("downloaded", 0)
+        already_downloaded = status.get("already_downloaded", 0)
+        total_downloaded += downloaded
+        total_already_downloaded += already_downloaded
+        if downloaded == 0 and already_downloaded > 0:
+            consecutive += 1
+            rprint(
+                f"😐 [powderblue]Number of consecutive calls with no new downloads:[/powderblue] [orange]{consecutive}/{max_consecutive}[/orange]"
             )
-            downloaded = status.get("downloaded", 0)
-            already_downloaded = status.get("already_downloaded", 0)
-            total_downloaded += downloaded
-            total_already_downloaded += already_downloaded
-            if downloaded == 0 and already_downloaded > 0:
-                consecutive += 1
-                rprint(
-                    f"😐 [powderblue]Number of consecutive calls with no new downloads:[/powderblue] [orange]{consecutive}/{max_consecutive}[/orange]"
-                )
-            else:
-                consecutive = 0
+        else:
+            consecutive = 0
 
-            call_count += 1
+        call_count += 1
 
-            if call_count % 10 == 0 and consecutive < max_consecutive:
-                delay = (
-                    delays[min(call_count // 10 - 1, len(delays) - 1)]
-                    if call_count // 10 <= len(delays)
-                    else 180
-                )
-                inline_countdown(delay)
+        if call_count % 10 == 0 and consecutive < max_consecutive:
+            delay = (
+                delays[min(call_count // 10 - 1, len(delays) - 1)]
+                if call_count // 10 <= len(delays)
+                else 180
+            )
+            inline_countdown(delay)
 
     rprint(
         f"[bold magenta]=== Result ===[/bold magenta]\n"


### PR DESCRIPTION
## Description

- Reuse per-thread SQLite connections instead of open/close on every DB call
- Skip redundant filename DB lookup when a URL record is already in hand
- Move `os.makedirs` out of the hot path — runs once per thread at connection init
- Parallelize landscape + portrait downloads in `_download_both_orientations`
- Build lowercased locale list once instead of twice in `download_multiple`
- Collapse redundant nested loop in `download_multiple_until_exhausted`