### PR TITLE
fix: prevent crash on API timeout, reuse HTTP session across all requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspotlightarchiver"
-version = "1.1.6"
+version = "1.1.7"
 authors = [
   { name="yell0wsuit" },
 ]

--- a/src/pyspotlightarchiver/helpers/v3_helper.py
+++ b/src/pyspotlightarchiver/helpers/v3_helper.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-import requests
+from pyspotlightarchiver.helpers.download_helper import _get_session
 
 
 def parse_v3_data(data, orientation="landscape", verbose=False):
@@ -49,6 +49,6 @@ def v3_helper(use_local=False, orientation="landscape", locale="en-us", verbose=
             f"&ua=WindowsShellClient%2F9.0.40929.0%20%28Windows%29"
             f"&bcnt=3&cdm=1"
         )
-        response = requests.get(url, timeout=10)
+        response = _get_session().get(url, timeout=10)
         data = response.json()
     return parse_v3_data(data, orientation=orientation, verbose=verbose)

--- a/src/pyspotlightarchiver/helpers/v4_helper.py
+++ b/src/pyspotlightarchiver/helpers/v4_helper.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-import requests
+from pyspotlightarchiver.helpers.download_helper import _get_session
 
 
 def parse_v4_data(data, orientation="landscape", verbose=False):
@@ -51,6 +51,6 @@ def v4_helper(use_local=False, orientation="landscape", locale="en-us", verbose=
             f"&locale={locale}"
             f"&fmt=json"
         )
-        response = requests.get(url, timeout=10)
+        response = _get_session().get(url, timeout=10)
         data = response.json()
     return parse_v4_data(data, orientation=orientation, verbose=verbose)

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -394,15 +394,20 @@ def download_multiple_until_exhausted(
     total_already_downloaded = 0
     while consecutive < max_consecutive:
         time.sleep(2)
-        status = download_multiple(
-            api_ver,
-            locale,
-            orientation,
-            verbose=verbose,
-            save_dir=save_dir,
-            embed_exif=embed_exif,
-            exiftool_path=exiftool_path,
-        )
+        try:
+            status = download_multiple(
+                api_ver,
+                locale,
+                orientation,
+                verbose=verbose,
+                save_dir=save_dir,
+                embed_exif=embed_exif,
+                exiftool_path=exiftool_path,
+            )
+        except requests.exceptions.RequestException as e:
+            rprint(f"⚠️ [yellow]Network error, retrying: {e}[/yellow]")
+            call_count += 1
+            continue
         downloaded = status.get("downloaded", 0)
         already_downloaded = status.get("already_downloaded", 0)
         total_downloaded += downloaded


### PR DESCRIPTION
## Description

- `v3_helper` and `v4_helper` now use the shared per-thread `requests.Session` instead of bare `requests.get()`
- `download_multiple_until_exhausted` catches `RequestException` and continues the loop instead of crashing the process
