### PR TITLE
refactor: Change message notification when no new images are downloaded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspotlightarchiver"
-version = "1.1.10"
+version = "1.1.11"
 authors = [
   { name="yell0wsuit" },
 ]

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -269,7 +269,7 @@ def _download_multiple_for_locale(
         new_entries.append(entry)
 
     if already_downloaded and not verbose:
-        rprint(f"ℹ️ [gray]Skipped {already_downloaded} already downloaded image(s).[/gray]")
+        rprint("ℹ️ [gray]No new images found, continuing...[/gray]")
 
     if not new_entries:
         return downloaded, already_downloaded


### PR DESCRIPTION
## Description

Change wording in `_download_multiple_for_locale` when images were already downloaded and verbose is off, print a generic notice `No new images found, continuing...` instead of `Skipped {already_downloaded} already downloaded image(s).` to provide a clearer, non-count-specific message in non-verbose mode.