### PR TITLE
feat: Replace ExifTool EXIF embedding with Pillow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ Inspired by [Spotlight-Downloader](https://github.com/ORelio/Spotlight-Downloade
 - List available Spotlight image URLs
 - Download Spotlight images in 1080p or 4K resolution
 - Filter by locale and orientation
-- Embed EXIF metadata with `exiftool`
+- Embed EXIF metadata with Pillow
 - Avoid duplicate downloads with perceptual hash and URL checks
 - Automatic throttling to avoid rate limits
 
 ## 📦 Requirements
 
 - Python 3.10 or higher ([Download Python](https://www.python.org/downloads/))
-- [`exiftool`](https://exiftool.org/) (optional, required for `--embed-exif`)
 
 ## ⚖️ Installation
 
@@ -106,8 +105,7 @@ pyspotlightarchiver download --single|--multiple [options]
 | `--locale`        | Locale code (e.g., `en-us`). Default: `en-us`.                              |
 | `--orientation`   | Image orientation: `landscape`, `portrait`, or `both`. Default: `landscape`. |
 | `--save-dir`      | Directory to save downloaded images. Default: `downloaded_spotlight`.       |
-| `--embed-exif`    | Embed EXIF metadata using `exiftool`.                                       |
-| `--exiftool-path` | Path to `exiftool`. Required if not in system `PATH`.                       |
+| `--embed-exif`    | Embed EXIF metadata.                                                        |
 | `--verbose`       | Show detailed logs.                                                         |
 
 ## 📌 Notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspotlightarchiver"
-version = "1.1.11"
+version = "1.2"
 authors = [
   { name="yell0wsuit" },
 ]
@@ -21,6 +21,7 @@ dependencies = [
   "requests",
   "babel",
   "imagededup",
+  "Pillow",
   "rich",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
 babel
 imagededup
+Pillow
 rich

--- a/src/pyspotlightarchiver/main.py
+++ b/src/pyspotlightarchiver/main.py
@@ -115,11 +115,6 @@ def main():
         action="store_true",
         help="Embed EXIF metadata in the images. Default: false",
     )
-    download_parser.add_argument(
-        "--exiftool-path",
-        type=str,
-        help="Path to the exiftool executable. Default: using the PATH environment variable",
-    )
 
     args = parser.parse_args()
 
@@ -142,7 +137,6 @@ def main():
                 args.verbose,
                 args.save_dir,
                 args.embed_exif,
-                args.exiftool_path,
             )
         elif args.multiple:
             init_db(args.save_dir)
@@ -153,7 +147,6 @@ def main():
                 args.verbose,
                 args.save_dir,
                 args.embed_exif,
-                args.exiftool_path,
             )
     else:
         parser.print_help()

--- a/src/pyspotlightarchiver/utils/download_utils.py
+++ b/src/pyspotlightarchiver/utils/download_utils.py
@@ -36,7 +36,7 @@ from pyspotlightarchiver.utils.locale_data import (
     get_locale_codes,
 )
 from pyspotlightarchiver.utils.exif_utils import (
-    set_exif_metadata_exiftool,
+    set_exif_metadata,
 )
 from pyspotlightarchiver.utils.countdown import (
     inline_countdown,
@@ -69,7 +69,7 @@ def _api_call(api_ver, locale, orientation, verbose=False):
 
 
 def _download_both_orientations(
-    entry, api_ver, save_dir=None, embed_exif=True, exiftool_path=None, verbose=False
+    entry, api_ver, save_dir=None, embed_exif=True, verbose=False
 ):
     found = False
     urls_to_download = []
@@ -97,13 +97,12 @@ def _download_both_orientations(
             filename = os.path.basename(path)
             add_image_url_to_db(url, compute_phash(path), filename, save_dir=save_dir)
             if embed_exif:
-                set_exif_metadata_exiftool(
+                set_exif_metadata(
                     path,
                     title=entry.get("title") or entry.get("picture_title"),
                     copyright_text=entry.get("copyright"),
                     caption_title=entry.get("caption_title"),
                     caption_description=entry.get("caption_description"),
-                    exiftool_path=exiftool_path,
                     verbose=verbose,
                 )
                 rprint(f"✅ [green]EXIF metadata embedded for:[/green] {filename}")
@@ -118,7 +117,6 @@ def _download_for_locale(
     verbose,
     save_dir=None,
     embed_exif=True,
-    exiftool_path=None,
 ):
     all_locales = get_locale_codes(api_ver, save_dir)
     all_locales_lower = [l.lower() for l in all_locales]
@@ -140,7 +138,7 @@ def _download_for_locale(
 
     if orientation == "both":
         return _download_both_orientations(
-            entry, api_ver, save_dir, embed_exif, exiftool_path
+            entry, api_ver, save_dir, embed_exif, verbose
         )
     url = entry.get("image_url")
     if url:
@@ -156,13 +154,12 @@ def _download_for_locale(
         filename = os.path.basename(path)
         add_image_url_to_db(url, compute_phash(path), filename, save_dir=save_dir)
         if embed_exif:
-            set_exif_metadata_exiftool(
+            set_exif_metadata(
                 path,
                 title=entry.get("title") or entry.get("picture_title"),
                 copyright_text=entry.get("copyright"),
                 caption_title=entry.get("caption_title"),
                 caption_description=entry.get("caption_description"),
-                exiftool_path=exiftool_path,
                 verbose=verbose,
             )
             rprint(f"✅ [green]EXIF metadata embedded for:[/green] {filename}")
@@ -170,9 +167,7 @@ def _download_for_locale(
     return False
 
 
-def _download_for_all_locales(
-    api_ver, orientation, verbose=False, save_dir=None, exiftool_path=None
-):
+def _download_for_all_locales(api_ver, orientation, verbose=False, save_dir=None):
     all_locales = get_locale_codes(api_ver, save_dir)
     locales_shuffled = all_locales[:]
     random.shuffle(locales_shuffled)
@@ -188,7 +183,6 @@ def _download_for_all_locales(
             verbose,
             operation=download_single,
             save_dir=save_dir,
-            exiftool_path=exiftool_path,
         ):
             return True
     if verbose:
@@ -205,7 +199,6 @@ def download_single(
     verbose=False,
     save_dir=None,
     embed_exif=True,
-    exiftool_path=None,
 ):
     """
     Download a single image (first entry) from the specified API version.
@@ -219,10 +212,9 @@ def download_single(
             orientation,
             verbose=verbose,
             save_dir=save_dir,
-            exiftool_path=exiftool_path,
         )
     result = _download_for_locale(
-        api_ver, locale, orientation, verbose, save_dir, embed_exif, exiftool_path
+        api_ver, locale, orientation, verbose, save_dir, embed_exif
     )
     if report_duplicates(save_dir):
         rprint(
@@ -238,7 +230,6 @@ def _download_multiple_for_locale(
     verbose=False,
     save_dir=None,
     embed_exif=True,
-    exiftool_path=None,
 ):
     """Helper to download all images for a single locale. Returns count."""
     entries = _api_call(api_ver, locale, orientation, verbose)
@@ -290,13 +281,12 @@ def _download_multiple_for_locale(
             for url, path, filename, phash in results:
                 add_image_url_to_db(url, phash, filename, save_dir=save_dir)
                 if embed_exif and locale != "all":
-                    set_exif_metadata_exiftool(
+                    set_exif_metadata(
                         path,
                         title=entry.get("title") or entry.get("picture_title"),
                         copyright_text=entry.get("copyright"),
                         caption_title=entry.get("caption_title"),
                         caption_description=entry.get("caption_description"),
-                        exiftool_path=exiftool_path,
                         verbose=verbose,
                     )
                     rprint(f"✅ [green]EXIF metadata embedded for:[/green] {filename}")
@@ -316,7 +306,6 @@ def download_multiple(
     verbose=False,
     save_dir=None,
     embed_exif=True,
-    exiftool_path=None,
 ):
     """
     Download multiple images (all entries) from the specified API version.
@@ -343,7 +332,6 @@ def download_multiple(
                     verbose,
                     operation=_download_multiple_for_locale,
                     save_dir=save_dir,
-                    exiftool_path=exiftool_path,
                     embed_exif=embed_exif,
                 )
                 total_downloaded += downloaded
@@ -372,7 +360,7 @@ def download_multiple(
     # Use the correctly-cased locale from all_locales
     real_locale = all_locales[all_locales_lower.index(locale)]
     downloaded, already_downloaded = _download_multiple_for_locale(
-        api_ver, real_locale, orientation, verbose, save_dir, embed_exif, exiftool_path
+        api_ver, real_locale, orientation, verbose, save_dir, embed_exif
     )
     return {"downloaded": downloaded, "already_downloaded": already_downloaded}
 
@@ -384,7 +372,6 @@ def download_multiple_until_exhausted(
     verbose=False,
     save_dir=None,
     embed_exif=True,
-    exiftool_path=None,
     max_consecutive=CONSECUTIVE_MAX,
 ):
     """
@@ -406,7 +393,6 @@ def download_multiple_until_exhausted(
                 verbose=verbose,
                 save_dir=save_dir,
                 embed_exif=embed_exif,
-                exiftool_path=exiftool_path,
             )
         except requests.exceptions.RequestException as e:
             rprint(f"⚠️ [yellow]Network error, retrying: {e}[/yellow]")

--- a/src/pyspotlightarchiver/utils/exif_utils.py
+++ b/src/pyspotlightarchiver/utils/exif_utils.py
@@ -1,111 +1,84 @@
-"""Module to set EXIF metadata using exiftool."""
+"""Module to set EXIF metadata using Pillow."""
 
-import subprocess
-import shutil
-import os
-import platform
-import tempfile
+from pathlib import Path
+
+from PIL import ExifTags, Image
 from rich import print as rprint
 
-
-def _exiftool_exists(exiftool_path=None):
-    if exiftool_path:
-        # If a directory is provided, look for exiftool executable inside it
-        if os.path.isdir(exiftool_path):
-            # Check for common exiftool executable names across platforms
-            system = platform.system()
-            if system == "Windows":
-                possible_names = ["exiftool.exe", "exiftool(-k).exe", "exiftool"]
-            else:  # macOS (Darwin) and Linux
-                possible_names = ["exiftool"]
-
-            for name in possible_names:
-                full_path = os.path.join(exiftool_path, name)
-                if os.path.isfile(full_path) and os.access(full_path, os.X_OK):
-                    return full_path
-            return None
-        # If a file path is provided, check if it exists and is executable
-        if os.path.isfile(exiftool_path) and os.access(exiftool_path, os.X_OK):
-            return exiftool_path
-        return None
-    # Fall back to checking if exiftool is in PATH
-    return shutil.which("exiftool")
+IMAGE_DESCRIPTION = 270
+COPYRIGHT = 33432
+USER_COMMENT = 37510
+XP_COMMENT = 40092
 
 
-def set_exif_metadata_exiftool(
+def _build_comment(caption_title=None, caption_description=None):
+    comment = ""
+    if caption_title:
+        comment += f"Title: {caption_title}"
+    if caption_description:
+        if comment:
+            comment += "\n\n"
+        comment += f"Description: {caption_description}"
+    return comment or None
+
+
+def _encode_user_comment(comment):
+    try:
+        return b"ASCII\x00\x00\x00" + comment.encode("ascii")
+    except UnicodeEncodeError:
+        return b"UNICODE\x00" + comment.encode("utf-16be")
+
+
+def _encode_xp_comment(comment):
+    return comment.encode("utf-16le") + b"\x00\x00"
+
+
+def set_exif_metadata(
     image_path,
     title=None,
     copyright_text=None,
     caption_title=None,
     caption_description=None,
-    exiftool_path=None,
     verbose=False,
 ):
-    """Method to set EXIF metadata using exiftool.
-    Args:
-        image_path (str): The path to the image file.
-        title (str): The title of the image.
-        copyright_text (str): The copyright text of the image.
-        caption_title (str): The title of the caption (v4 only). Stored as comment.
-        caption_description (str): The description of the caption (v4 only). Stored as comment.
-        exiftool_path (str): The path to the exiftool executable or directory containing it.
-    """
-    exiftool_cmd = _exiftool_exists(exiftool_path)
-
-    if not exiftool_cmd:
-        if exiftool_path:
-            rprint(
-                f"❌ [red]ExifTool cannot be found at '{exiftool_path}'. Please check the path or install it from https://exiftool.org/[/red]"
-            )
-        else:
-            rprint(
-                "❌ [red]ExifTool cannot be found. Please install it from https://exiftool.org/, or specify the path with --exiftool-path.[/red]"
-            )
-        return
-
-    args = [exiftool_cmd, "-overwrite_original", "-charset", "utf8"]
-    if title:
-        args.append(f"-ImageDescription={title}")
-        if verbose:
-            rprint(f"ℹ️ [gray]LOG: [exiftool] Title:[/gray] {title}")
-    if copyright_text:
-        args.append(f"-Copyright={copyright_text}")
-        if verbose:
-            rprint(f"ℹ️ [gray]LOG: [exiftool] Copyright:[/gray] {copyright_text}")
-    if caption_title or caption_description:
-        comment = ""
-        if caption_title:
-            comment += f"Title: {caption_title}"
-        if caption_description:
-            if comment:
-                comment += "\n\n"
-            comment += f"Description: {caption_description}"
-
-        # Write comment to a temporary file (UTF-8 encoding)
-        with tempfile.NamedTemporaryFile(
-            "w", delete=False, encoding="utf-8", suffix=".txt"
-        ) as tf:
-            tf.write(comment)
-            temp_comment_path = tf.name
-
-        args.append(f"-UserComment<={temp_comment_path}")
-        args.append(f"-XPComment<={temp_comment_path}")
-        if verbose:
-            rprint(f"ℹ️ [gray]LOG: [exiftool] Comment:[/gray] {comment}")
-    else:
-        temp_comment_path = None
-
-    args.append(image_path)
+    """Set EXIF metadata on an image using Pillow."""
+    image_path = Path(image_path)
+    comment = _build_comment(caption_title, caption_description)
 
     try:
-        result = subprocess.run(args, capture_output=True, text=True, check=True)
+        with Image.open(image_path) as image:
+            exif = image.getexif()
+            if title:
+                exif[IMAGE_DESCRIPTION] = title
+                if verbose:
+                    rprint(f"ℹ️ [gray]LOG: [pillow] Title:[/gray] {title}")
+            if copyright_text:
+                exif[COPYRIGHT] = copyright_text
+                if verbose:
+                    rprint(f"ℹ️ [gray]LOG: [pillow] Copyright:[/gray] {copyright_text}")
+            if comment:
+                exif_ifd = exif.get_ifd(ExifTags.IFD.Exif)
+                exif_ifd[USER_COMMENT] = _encode_user_comment(comment)
+                exif[ExifTags.IFD.Exif] = exif_ifd
+                exif[XP_COMMENT] = _encode_xp_comment(comment)
+                if verbose:
+                    rprint(f"ℹ️ [gray]LOG: [pillow] Comment:[/gray] {comment}")
+
+            if image.format == "JPEG":
+                image.save(
+                    image_path,
+                    exif=exif.tobytes(),
+                    quality="keep",
+                    subsampling="keep",
+                )
+            else:
+                image.save(image_path, exif=exif.tobytes())
+
         if verbose:
             rprint(
-                f"✅ [green]LOG: [exiftool] EXIF metadata written to:[/green] {image_path} using exiftool. Output: {result.stdout}"
+                f"✅ [green]LOG: [pillow] EXIF metadata written to:[/green] {image_path}"
             )
-    except subprocess.CalledProcessError as e:
-        if verbose:
-            rprint(f"❌ [red]LOG: [exiftool] ExifTool error:[/red] {e.stderr}")
     except Exception as e:  # pylint: disable=broad-exception-caught
-        # We don't know what kind of exception until runtime
-        rprint(f"❌ [red]LOG: [exiftool] Unexpected error ({type(e).__name__}):[/red] {e}")
+        rprint(
+            f"❌ [red]LOG: [pillow] Unexpected error ({type(e).__name__}):[/red] {e}"
+        )


### PR DESCRIPTION
## Description

Replaces the external ExifTool dependency for EXIF metadata embedding with Pillow-native EXIF writing.

## Changes

- Added Pillow-based EXIF writer for `ImageDescription`, `Copyright`, `UserComment`, and `XPComment`
- Removed `--exiftool-path` CLI option and all ExifTool path plumbing
- Added Pillow as an explicit dependency